### PR TITLE
Preset passphrase for all keygrips of priv key

### DIFF
--- a/src/gpg.ts
+++ b/src/gpg.ts
@@ -123,19 +123,18 @@ export const importKey = async (armoredText: string): Promise<string> => {
     });
 };
 
-export const getKeygrip = async (fingerprint: string): Promise<string> => {
+export const getKeygrips = async (fingerprint: string): Promise<Array<string>> => {
   return await exec.exec('gpg', ['--batch', '--with-colons', '--with-keygrip', '--list-secret-keys', fingerprint], true).then(res => {
     if (res.stderr != '' && !res.success) {
       throw new Error(res.stderr);
     }
-    let keygrip: string = '';
+    let keygrips: Array<string> = [];
     for (let line of res.stdout.replace(/\r/g, '').trim().split(/\n/g)) {
       if (line.startsWith('grp')) {
-        keygrip = line.replace(/(grp|:)/g, '').trim();
-        break;
+        keygrips.push(line.replace(/(grp|:)/g, '').trim());
       }
     }
-    return keygrip;
+    return keygrips;
   });
 };
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -45,13 +45,14 @@ async function run(): Promise<void> {
       await gpg.configureAgent(gpg.agentConfig);
 
       core.info('📌 Getting keygrip');
-      const keygrip = await gpg.getKeygrip(privateKey.fingerprint);
-      core.debug(`${keygrip}`);
+      const keygrips = await gpg.getKeygrips(privateKey.fingerprint);
 
-      core.info('🔓 Presetting passphrase');
-      await gpg.presetPassphrase(keygrip, process.env.PASSPHRASE).then(stdout => {
-        core.debug(stdout);
-      });
+      for (var i = 0; i < keygrips.length; i++) {
+        core.info(`🔓 Presetting passphrase for ${keygrips[i]}`);
+        await gpg.presetPassphrase(keygrips[i], process.env.PASSPHRASE).then(stdout => {
+          core.debug(stdout);
+        });
+      }
     }
 
     core.info('🛒 Setting outputs...');


### PR DESCRIPTION
Sometimes, private keys may have more than one keygrip.

It's necessary to preset the passphrase for all keygrips of the private key